### PR TITLE
fixed a bug where entering an empty string raises an error if using a delimiter

### DIFF
--- a/lib/ocamline.ml
+++ b/lib/ocamline.ml
@@ -29,7 +29,7 @@ let _ends_with s d ds =
       let b = d.[ds - i] in
       a = b && aux (i - 1)
     | _ -> true in
-  aux ds
+  if ss = 0 || ss < ds then false else aux ds
 
 (* Counts how many time a character appears in a string *)
 let _count_char c strings str =


### PR DESCRIPTION
Could you please make a new release in the opam repository, so that my gobba programming language does no longer throw "IndexOutOfBounds" when an empty line is entered in the repl? Thank you for the cool library anyways.